### PR TITLE
Add in the attrition records drop when creating concept cohort

### DIFF
--- a/R/measurementCohort.R
+++ b/R/measurementCohort.R
@@ -141,20 +141,14 @@ measurementCohort <- function(cdm,
       cohortCodelist |> dplyr::select("concept_id", "cohort_definition_id"),
       by = "concept_id"
     ) |>
-    dplyr::compute(name = name, temporary = FALSE) |>
-    omopgenerics::newCohortTable(
-      cohortSetRef = cohortSet,
-      cohortCodelistRef = cohortCodelist |> dplyr::collect(),
-      .softValidation = TRUE
-    )
+    dplyr::compute(name = name, temporary = FALSE)
 
   if (!is.null(valueAsConcept) || !is.null(valueAsNumber)) {
     cli::cli_inform(c("i" = "Applying measurement requirements."))
     filterExpr <- getFilterExpression(valueAsConcept, valueAsNumber)
     cohort <- cohort |>
       dplyr::filter(!!!filterExpr) |>
-      dplyr::compute(name = name, temporary = FALSE) |>
-      omopgenerics::recordCohortAttrition(reason = "Fulfilling measurement value requirements")
+      dplyr::compute(name = name, temporary = FALSE)
 
     if (cohort |> dplyr::tally() |> dplyr::pull("n") == 0) {
       cli::cli_warn(
@@ -162,6 +156,13 @@ measurementCohort <- function(cdm,
       )
     }
   }
+
+  cohort <- cohort |>
+    omopgenerics::newCohortTable(
+      cohortSetRef = cohortSet,
+      cohortCodelistRef = cohortCodelist |> dplyr::collect(),
+      .softValidation = TRUE
+    )
 
   if (cohort |> dplyr::tally() |> dplyr::pull("n") == 0) {
     cli::cli_inform(c("i" = "No table could be subsetted, returning empty cohort."))

--- a/R/validateFunctions.R
+++ b/R/validateFunctions.R
@@ -184,7 +184,7 @@ validateStrata <- function(strata, cohort) {
 validateValueAsNumber <- function(valueAsNumber) {
   omopgenerics::assertList(valueAsNumber,
     named = TRUE,
-    class = "numeric",
+    class = c("integer", "numeric"),
     null = TRUE
   )
   for (i in seq_along(valueAsNumber)) {

--- a/tests/testthat/test-conceptCohort.R
+++ b/tests/testthat/test-conceptCohort.R
@@ -4,7 +4,7 @@ test_that("expected errors and messages", {
     omock::mockObservationPeriod()
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "concept", table = dplyr::tibble(
-      "concept_id" = 1,
+      "concept_id" = 1L,
       "concept_name" = "my concept",
       "domain_id" = "adsf",
       "vocabulary_id" = NA,
@@ -37,10 +37,10 @@ test_that("expected errors and messages", {
   expect_true(attrition(x) |> nrow() == 0)
 
   # not codelist
-  expect_error(x <- conceptCohort(cdm = cdm, conceptSet = 1, name = "cohort"))
-  expect_error(x <- conceptCohort(cdm = cdm, conceptSet = list(1), name = "cohort"))
+  expect_error(x <- conceptCohort(cdm = cdm, conceptSet = 1L, name = "cohort"))
+  expect_error(x <- conceptCohort(cdm = cdm, conceptSet = list(1L), name = "cohort"))
   expect_message(expect_message(
-    x <- conceptCohort(cdm = cdm, conceptSet = list(a = 1), name = "cohort")
+    x <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L), name = "cohort")
   ))
   expect_true(inherits(x, "cohort_table"))
   expect_true(x |> dplyr::collect() |> nrow() == 0)
@@ -57,7 +57,7 @@ test_that("expected errors and messages", {
   expect_true(nrow(attrition(x)) == 1)
   expect_true(nrow(attr(x, "cohort_codelist")) == 1)
   expect_message(expect_message(
-    x <- conceptCohort(cdm = cdm, conceptSet = list(a = 2), name = "cohort")
+    x <- conceptCohort(cdm = cdm, conceptSet = list(a = 2L), name = "cohort")
   ))
 
 })
@@ -116,7 +116,7 @@ test_that("simple example", {
                  "dbcon"))
   }
   expect_no_error(cohort <- conceptCohort(cdm = cdm,
-                                          conceptSet = list(a = 1),
+                                          conceptSet = list(a = 1L),
                                           name = "my_cohort"))
   if(isDuckdb){
     endTempTables <- countDuckdbTempTables(
@@ -137,12 +137,26 @@ test_that("simple example", {
   expect_true(cohort |> dplyr::tally() |> dplyr::pull() == 4)
   expect_true(cohortCount(cohort)$number_records == 4)
   expect_true(cohortCount(cohort)$number_subjects == 2)
-  # expect_true(attrition(cohort) |> nrow() == 1)
   expect_identical(
     settings(cohort),
     dplyr::tibble(
       "cohort_definition_id" = 1L, "cohort_name" = "a",
       "cdm_version" = attr(cdm, "cdm_version"), "vocabulary_version" = "mock"
+    )
+  )
+  expect_identical(
+    attrition(cohort) |> dplyr::as_tibble(),
+    dplyr::tibble(
+      "cohort_definition_id" = 1L,
+      "number_records" = c(9L, 9L, 9L, 4L),
+      "number_subjects" = 2L,
+      "reason_id" = 1:4L,
+      "reason" = c(
+        "Initial qualifying events", "Record start <= record end",
+        "Record in observation", "Collapse overlapping records"
+      ),
+      "excluded_records" = c(0L, 0L, 0L, 5L),
+      "excluded_subjects" = 0L
     )
   )
   expect_identical(cohortCodelist(cohort, 1), omopgenerics::newCodelist(list(a = 1L)))
@@ -176,18 +190,18 @@ test_that("simple example", {
       )
     )
   cohort2 <- conceptCohort(cdm = cdm,
-                           conceptSet = list(a = 1),
+                           conceptSet = list(a = 1L),
                            name = "my_cohort2",
                            subsetCohort = cdm$cohort)
   expect_equal(collectCohort(cohort2, 1), collectCohort(cohort, 1))
   cohort3 <- conceptCohort(cdm = cdm,
-                           conceptSet = list(a = 1),
+                           conceptSet = list(a = 1L),
                            name = "my_cohort3",
                            subsetCohort = cdm$cohort,
                            subsetCohortId = 2)
   expect_true(nrow(collectCohort(cohort3, 1)) == 0)
   expect_error(conceptCohort(cdm = cdm,
-                             conceptSet = list(a = 1),
+                             conceptSet = list(a = 1L),
                              name = "my_cohort3",
                              subsetCohort = cdm$cohort,
                              subsetCohortId = 3))
@@ -199,14 +213,14 @@ test_that("simple example duckdb", {
   testthat::skip_on_cran()
   cdm <- omock::mockCdmReference() |>
     omock::mockCdmFromTables(tables = list("cohort" = dplyr::tibble(
-      "cohort_definition_id" = 1,
-      "subject_id" = c(1, 2, 3),
+      "cohort_definition_id" = 1L,
+      "subject_id" = 1:3L,
       "cohort_start_date" = as.Date("2020-01-01"),
       "cohort_end_date" = as.Date("2029-12-31")
     )))
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "concept", table = dplyr::tibble(
-      "concept_id" = 1,
+      "concept_id" = 1L,
       "concept_name" = "my concept",
       "domain_id" = "drUg",
       "vocabulary_id" = NA,
@@ -218,12 +232,12 @@ test_that("simple example duckdb", {
   )
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "drug_exposure", table = dplyr::tibble(
-      "drug_exposure_id" = 1:11,
-      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1),
-      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1),
+      "drug_exposure_id" = 1:11L,
+      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1) |> as.integer(),
+      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1) |> as.integer(),
       "drug_exposure_start_date" = c(0, 300, 1500, 750, 10, 800, 150, 1800, 1801, 1802, 1803),
       "drug_exposure_end_date" = c(400, 800, 1600, 1550, 2000, 1000, 600, 1801, 1802, 1803, 1804),
-      "drug_type_concept_id" = 1
+      "drug_type_concept_id" = 1L
     ) |>
       dplyr::mutate(
         "drug_exposure_start_date" = as.Date(.data$drug_exposure_start_date, origin = "2020-01-01"),
@@ -233,11 +247,11 @@ test_that("simple example duckdb", {
 
   cdm <- cdm |> copyCdm()
 
-  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1), name = "cohort"))
+  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L), name = "cohort"))
 
   expect_true(cohort |> dplyr::tally() |> dplyr::pull() == 4)
-  expect_true(cohortCount(cohort)$number_records == 4)
-  expect_true(cohortCount(cohort)$number_subjects == 2)
+  expect_true(cohortCount(cohort)$number_records == 4L)
+  expect_true(cohortCount(cohort)$number_subjects == 2L)
   # expect_true(attrition(cohort) |> nrow() == 1)
   expect_identical(
     settings(cohort),
@@ -271,8 +285,8 @@ test_that("concepts from multiple cdm tables duckdb", {
   testthat::skip_on_cran()
   cdm <- omock::mockCdmReference() |>
     omock::mockCdmFromTables(tables = list("cohort" = dplyr::tibble(
-      "cohort_definition_id" = 1,
-      "subject_id" = c(1, 2, 3),
+      "cohort_definition_id" = 1L,
+      "subject_id" = c(1L, 2L, 3L),
       "cohort_start_date" = as.Date("2020-01-01"),
       "cohort_end_date" = as.Date("2029-12-31")
     ))) |>
@@ -283,11 +297,13 @@ test_that("concepts from multiple cdm tables duckdb", {
   cs <- list("a" = cdm$condition_occurrence |>
                dplyr::select("condition_concept_id") |>
                head(1)|>
-               dplyr::pull(),
+               dplyr::pull() |>
+               as.integer(),
              "b" = cdm$drug_exposure |>
                dplyr::select("drug_concept_id") |>
                head(1) |>
-               dplyr::pull())
+               dplyr::pull() |>
+               as.integer())
 
   expect_no_error(cohort <- conceptCohort(cdm = cdm,
                                           conceptSet = cs,
@@ -299,14 +315,14 @@ test_that("excluded concepts in codelist", {
   testthat::skip_on_cran()
   cdm <- omock::mockCdmReference() |>
     omock::mockCdmFromTables(tables = list("cohort" = dplyr::tibble(
-      "cohort_definition_id" = 1,
-      "subject_id" = c(1, 2, 3),
+      "cohort_definition_id" = 1L,
+      "subject_id" = c(1L, 2L, 3L),
       "cohort_start_date" = as.Date("2020-01-01"),
       "cohort_end_date" = as.Date("2029-12-31")
     )))
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "concept", table = dplyr::tibble(
-      "concept_id" = 1,
+      "concept_id" = 1L,
       "concept_name" = "my concept",
       "domain_id" = "drUg",
       "vocabulary_id" = NA,
@@ -318,9 +334,9 @@ test_that("excluded concepts in codelist", {
   )
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "drug_exposure", table = dplyr::tibble(
-      "drug_exposure_id" = 1:11,
-      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1),
-      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1),
+      "drug_exposure_id" = 1:11L,
+      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1) |> as.integer(),
+      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1) |> as.integer(),
       "drug_exposure_start_date" = c(0, 300, 1500, 750, 10, 800, 150, 1800, 1801, 1802, 1803),
       "drug_exposure_end_date" = c(400, 800, 1600, 1550, 2000, 1000, 600, 1801, 1802, 1803, 1804),
       "drug_type_concept_id" = 1
@@ -333,10 +349,10 @@ test_that("excluded concepts in codelist", {
 
   cdm <- cdm |> copyCdm()
 
-  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1:2), name = "cohort1"))
+  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1:2L), name = "cohort1"))
   expect_true(all(attr(cohort, "cohort_codelist") |> dplyr::pull("concept_id") |> sort() == 1:2))
 
-  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 2:3), name = "cohort2"))
+  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 2:3L), name = "cohort2"))
   expect_true(all(attr(cohort, "cohort_codelist") |> dplyr::pull("concept_id") |> sort() == 2:3))
 
   PatientProfiles::mockDisconnect(cdm)
@@ -348,7 +364,7 @@ test_that("out of observation", {
     omock::mockPerson(n = 4, seed = 1) |>
     omock::mockObservationPeriod(seed = 1)
   cdm_local$concept <- dplyr::tibble(
-    "concept_id" = c(1, 2),
+    "concept_id" = c(1L, 2L),
     "concept_name" = c("my concept 1", "my concept 2"),
     "domain_id" = "Drug",
     "vocabulary_id" = NA,
@@ -358,12 +374,12 @@ test_that("out of observation", {
     "valid_end_date" = NA
   )
   cdm_local$drug_exposure <- dplyr::tibble(
-    "drug_exposure_id" = 1:13,
-    "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1, 4, 4),
-    "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1, 1, 2),
+    "drug_exposure_id" = 1:13L,
+    "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1, 4, 4) |> as.integer(),
+    "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1, 1, 2) |> as.integer(),
     "drug_exposure_start_date" = c(0, 300, 1500, 750, 10, 800, 150, 1800, 1801, 1802, 1803, 430, -10),
     "drug_exposure_end_date" = c(400, 800, 1600, 1550, 2000, 1000, 600, 1801, 1802, 1803, 1804, 400, -100),
-    "drug_type_concept_id" = 1
+    "drug_type_concept_id" = 1L
   ) |>
     dplyr::mutate(
       "drug_exposure_start_date" = as.Date(.data$drug_exposure_start_date, origin = "2010-01-01"),
@@ -376,7 +392,7 @@ test_that("out of observation", {
   # start end before (subject 3)
   # end event < start event (subject 4)
   cdm$cohort1 <- conceptCohort(cdm = cdm,
-                               conceptSet = list(a = 1, b = 2), name = "cohort1")
+                               conceptSet = list(a = 1L, b = 2L), name = "cohort1")
   expect_true(all(c("cohort_table", "cdm_table") %in% class(cdm$cohort1)))
   # person 1 has two cohort entries
   # the first - same dates as drug exposure
@@ -408,7 +424,7 @@ test_that("out of observation", {
     omock::mockPerson(n = 4, seed = 1) |>
     omock::mockObservationPeriod(seed = 1)
   cdm_local$concept <- dplyr::tibble(
-    "concept_id" = c(1, 2),
+    "concept_id" = c(1L, 2L),
     "concept_name" = c("my concept 1", "my concept 2"),
     "domain_id" = "Drug",
     "vocabulary_id" = NA,
@@ -418,16 +434,16 @@ test_that("out of observation", {
     "valid_end_date" = NA
   )
   cdm_local$drug_exposure <- dplyr::tibble(
-    "drug_exposure_id" = 1:4,
-    "person_id" = c(1, 3, 4, 2),
-    "drug_concept_id" = 1,
+    "drug_exposure_id" = 1:4L,
+    "person_id" = c(1L, 3L, 4L, 2L),
+    "drug_concept_id" = 1L,
     "drug_exposure_start_date" = as.Date(c("2004-01-01", "2014-01-01", "2001-01-01", "2000-01-01")),
     "drug_exposure_end_date" = as.Date(c("2015-01-01", "2015-05-01", "2002-01-01", "2000-02-02")),
-    "drug_type_concept_id" = 1
+    "drug_type_concept_id" = 1L
   )
   cdm <- cdm_local |> copyCdm()
 
-  cdm$cohort2 <- conceptCohort(cdm = cdm, conceptSet = list(a = 1, b = 2), name = "cohort2")
+  cdm$cohort2 <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L, b = 2L), name = "cohort2")
   expect_true(all(c("cohort_table", "cdm_table") %in% class(cdm$cohort2)))
   expect_true(all(cdm$cohort2 |> dplyr::pull("subject_id") |> sort() == c(1, 2, 4)))
   expect_true(all(cdm$cohort2 |> dplyr::pull("cohort_start_date") |> sort() ==
@@ -449,7 +465,7 @@ test_that("out of observation", {
     omock::mockPerson(n = 4, seed = 1) |>
     omock::mockObservationPeriod(seed = 1)
   cdm_local$concept <- dplyr::tibble(
-    "concept_id" = c(1, 2),
+    "concept_id" = c(1L, 2L),
     "concept_name" = c("my concept 1", "my concept 2"),
     "domain_id" = "Drug",
     "vocabulary_id" = NA,
@@ -459,17 +475,17 @@ test_that("out of observation", {
     "valid_end_date" = NA
   )
   cdm_local$drug_exposure <- dplyr::tibble(
-    "drug_exposure_id" = 1:6,
-    "person_id" = c(1, 2, 2, 3, 4, 4),
-    "drug_concept_id" = c(1, 1, 1, 1, 2, 2),
+    "drug_exposure_id" = 1:6L,
+    "person_id" = c(1, 2, 2, 3, 4, 4) |> as.integer(),
+    "drug_concept_id" = c(1, 1, 1, 1, 2, 2) |> as.integer(),
     "drug_exposure_start_date" = as.Date(c("2004-01-01", "2014-01-01", "2015-04-01", "2000-01-01", "2000-01-01", "1999-01-01")),
     "drug_exposure_end_date" = as.Date(c("2003-01-01", "2015-05-01", "2015-07-01", "2000-02-02", "2000-01-01", "2001-01-01")),
-    "drug_type_concept_id" = 1
+    "drug_type_concept_id" = 1L
   )
   cdm <- cdm_local |> copyCdm()
 
   # empty cohort
-  cdm$cohort3 <- conceptCohort(cdm = cdm, conceptSet = list(a = 1), name = "cohort3")
+  cdm$cohort3 <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L), name = "cohort3")
   expect_true(all(colnames(cdm$cohort3) ==
                     c("cohort_definition_id", "subject_id", "cohort_start_date", "cohort_end_date")))
   expect_true(all(c("cohort_table", "cdm_table") %in% class(cdm$cohort3)))
@@ -477,7 +493,7 @@ test_that("out of observation", {
   expect_true(cohortCodelist(cdm$cohort3, 1)$a == 1)
 
   # empty cohort
-  cdm$cohort4 <- conceptCohort(cdm = cdm, conceptSet = list(a = 1, b = 2), name = "cohort4")
+  cdm$cohort4 <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L, b = 2L), name = "cohort4")
   expect_true(all(c("cohort_table", "cdm_table") %in% class(cdm$cohort4)))
   expect_true(cdm$cohort4 |> dplyr::tally() |> dplyr::pull("n") == 1)
   expect_true(cohortCodelist(cdm$cohort4, 1)$a == 1)
@@ -492,14 +508,14 @@ test_that("table not present in the cdm", {
   testthat::skip_on_cran()
   cdm <- omock::mockCdmReference() |>
     omock::mockCdmFromTables(tables = list("cohort" = dplyr::tibble(
-      "cohort_definition_id" = 1,
-      "subject_id" = c(1, 2, 3),
+      "cohort_definition_id" = 1L,
+      "subject_id" = c(1L, 2L, 3L),
       "cohort_start_date" = as.Date("2020-01-01"),
       "cohort_end_date" = as.Date("2029-12-31")
     )))
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "concept", table = dplyr::tibble(
-      "concept_id" = 1:2,
+      "concept_id" = 1:2L,
       "concept_name" = c("my concept", "my other concept"),
       "domain_id" = c("drug", "condition"),
       "vocabulary_id" = NA,
@@ -511,12 +527,12 @@ test_that("table not present in the cdm", {
   )
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "drug_exposure", table = dplyr::tibble(
-      "drug_exposure_id" = 1:11,
-      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1),
-      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1),
+      "drug_exposure_id" = 1:11L,
+      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1) |> as.integer(),
+      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 2, 1) |> as.integer(),
       "drug_exposure_start_date" = c(0, 300, 1500, 750, 10, 800, 150, 1800, 1801, 1802, 1803),
       "drug_exposure_end_date" = c(400, 800, 1600, 1550, 2000, 1000, 600, 1801, 1802, 1803, 1804),
-      "drug_type_concept_id" = 1
+      "drug_type_concept_id" = 1L
     ) |>
       dplyr::mutate(
         "drug_exposure_start_date" = as.Date(.data$drug_exposure_start_date, origin = "2020-01-01"),
@@ -526,7 +542,7 @@ test_that("table not present in the cdm", {
 
   cdm <- cdm |> copyCdm()
 
-  expect_warning(cdm$conceptcohort <- conceptCohort(cdm, list(a = 1, b = 1, c = 1:2, d = 2), name = "conceptcohort"))
+  expect_warning(cdm$conceptcohort <- conceptCohort(cdm, list(a = 1L, b = 1L, c = 1:2L, d = 2L), name = "conceptcohort"))
   expect_true(all(cdm$conceptcohort |> dplyr::pull(cohort_definition_id) |> unique() |> sort() == 1:3))
   expect_true(all(cdm$conceptcohort |> dplyr::pull(cohort_start_date) |> sort() ==
                     c("2020-01-01", "2020-01-01", "2020-01-01", "2020-01-11", "2020-01-11",
@@ -584,7 +600,7 @@ test_that("cohort exit as event start date", {
 
   # exit as event start
   expect_no_error(cdm$cohort_1 <- conceptCohort(cdm = cdm,
-                                                conceptSet = list(a = 1),
+                                                conceptSet = list(a = 1L),
                                                 name = "cohort_1",
                                                 exit = "event_start_date"))
   expect_true(nrow(cdm$cohort_1 |>
@@ -604,7 +620,7 @@ test_that("cohort exit as event start date", {
                                              name = "cohort_1",
                                              exit = "not_an_option"))
 
-
+  PatientProfiles::mockDisconnect(cdm)
 })
 
 test_that("use source field concepts", {
@@ -667,14 +683,14 @@ test_that("missing event end dates", {
   testthat::skip_on_cran()
   cdm <- omock::mockCdmReference() |>
     omock::mockCdmFromTables(tables = list("cohort" = dplyr::tibble(
-      "cohort_definition_id" = 1,
-      "subject_id" = c(1, 2, 3),
+      "cohort_definition_id" = 1L,
+      "subject_id" = c(1L, 2L, 3L),
       "cohort_start_date" = as.Date("2020-01-01"),
       "cohort_end_date" = as.Date("2029-12-31")
     )))
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "concept", table = dplyr::tibble(
-      "concept_id" = 1,
+      "concept_id" = 1L,
       "concept_name" = "my concept",
       "domain_id" = "drUg",
       "vocabulary_id" = NA,
@@ -686,12 +702,12 @@ test_that("missing event end dates", {
   )
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "drug_exposure", table = dplyr::tibble(
-      "drug_exposure_id" = 1:11,
-      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1),
-      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1),
+      "drug_exposure_id" = 1:11L,
+      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1) |> as.integer(),
+      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1) |> as.integer(),
       "drug_exposure_start_date" = c(0, 300, 1500, 750, 10, 800, 150, 1800, 1801, 1802, 1803),
       "drug_exposure_end_date" = c(400, 800, 1600, 1550, 2000, 1000, 600, 1801, 1802, 1803, 1804),
-      "drug_type_concept_id" = 1
+      "drug_type_concept_id" = 1L
     ) |>
       dplyr::mutate(
         "drug_exposure_start_date" = as.Date(.data$drug_exposure_start_date, origin = "2020-01-01"),
@@ -699,7 +715,7 @@ test_that("missing event end dates", {
       )
   )
   cdm <- cdm |> copyCdm()
-  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1), name = "cohort"))
+  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L), name = "cohort"))
   startCount <- cohortCount(cohort) |>
     dplyr::pull("number_subjects")
 
@@ -707,23 +723,22 @@ test_that("missing event end dates", {
   # as their missing end date will have been replaced by the start date
   cdm <- omopgenerics::insertTable(
     cdm = cdm, name = "drug_exposure", table = dplyr::tibble(
-      "drug_exposure_id" = 1:11,
-      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1),
-      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1),
+      "drug_exposure_id" = 1:11L,
+      "person_id" = c(1, 1, 1, 1, 2, 2, 3, 1, 1, 1, 1) |> as.integer(),
+      "drug_concept_id" = c(1, 1, 1, 2, 1, 1, 2, 1, 1, 1, 1) |> as.integer(),
       "drug_exposure_start_date" = c(0, 300, 1500, 750, 10, 800, 150, 1800, 1801, 1802, 1803),
       "drug_exposure_end_date" = as.Date(NA),
-      "drug_type_concept_id" = 1
+      "drug_type_concept_id" = 1L
     ) |>
       dplyr::mutate(
         "drug_exposure_start_date" = as.Date(.data$drug_exposure_start_date, origin = "2020-01-01")
       )
   )
-  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1), name = "cohort"))
+  expect_no_error(cohort <- conceptCohort(cdm = cdm, conceptSet = list(a = 1L), name = "cohort"))
   endCount <- cohortCount(cohort) |>
     dplyr::pull("number_subjects")
 
   expect_identical(startCount, endCount)
-
 
   PatientProfiles::mockDisconnect(cdm)
 })

--- a/tests/testthat/test-measurementCohort.R
+++ b/tests/testthat/test-measurementCohort.R
@@ -77,16 +77,16 @@ test_that("mearurementCohorts works", {
     cdm$cohort |> attrition() |> dplyr::as_tibble(),
     dplyr::tibble(
       "cohort_definition_id" = 1L,
-      "number_records" = c(5L, rep(2L, 4)),
-      "number_subjects" = c(3L, rep(2L, 4)),
-      "reason_id" = 1:5L,
+      "number_records" = c(rep(2L, 4)),
+      "number_subjects" = c(rep(2L, 4)),
+      "reason_id" = 1:4L,
       "reason" = c(
-        "Initial qualifying events", "Fulfilling measurement value requirements",
+        "Initial qualifying events",
         "Not missing record date", "Record in observation",
         "Distinct measurement records"
       ),
-      "excluded_records" = c(0L, 3L, 0L, 0L, 0L),
-      "excluded_subjects" = c(0L, 1L, 0L, 0L, 0L),
+      "excluded_records" = c(0L, 0L, 0L, 0L),
+      "excluded_subjects" = c(0L, 0L, 0L, 0L),
     )
   )
   expect_true(settings(cdm$cohort)$cohort_name == "normal_blood_pressure")


### PR DESCRIPTION
**- conceptCohort attrition:**
```
>  attrition(cohort)
# A tibble: 4 × 7
  cohort_definition_id number_records number_subjects reason_id reason                       excluded_records excluded_subjects
                 <int>          <int>           <int>     <int> <chr>                                   <int>             <int>
1                    1              9               2         1 Initial qualifying events                   0                 0
2                    1              9               2         2 Record start <= record end                  0                 0
3                    1              9               2         3 Record in observation                       0                 0
4                    1              4               2         4 Collapse overlapping records                5                 0
```

**- measurementCohort attrition( (after PR revision):**
```
> cdm$cohort |> attrition()
# A tibble: 5 × 7
  cohort_definition_id number_records number_subjects reason_id reason                                    excluded_records excluded_subjects
                 <int>          <int>           <int>     <int> <chr>                                                <int>             <int>
1                    1              5               3         1 Initial qualifying events                                0                 0
3                    1              2               2         2 Not missing record date                                  0                 0
4                    1              2               2         3 Record in observation                                    0                 0
5                    1              2               2         4 Distinct measurement records                             0                 0
```