### PR TITLE
To fix tests

### DIFF
--- a/R/collapseCohorts.R
+++ b/R/collapseCohorts.R
@@ -41,7 +41,7 @@ collapseCohorts <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE)
     return(cdm[[name]])

--- a/R/exitAtColumnDate.R
+++ b/R/exitAtColumnDate.R
@@ -123,7 +123,7 @@ exitAtColumnDate <- function(cohort,
   omopgenerics::assertLogical(.softValidation, length = 1, call = call)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_exitAtColumnDate_entryCohort_")

--- a/R/exitAtDate.R
+++ b/R/exitAtDate.R
@@ -44,7 +44,7 @@ exitAtObservationEnd <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |>
       dplyr::compute(name = name, temporary = FALSE,
@@ -174,7 +174,7 @@ exitAtDeath <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |>
       dplyr::compute(name = name, temporary = FALSE,

--- a/R/matchCohorts.R
+++ b/R/matchCohorts.R
@@ -61,7 +61,7 @@ matchCohorts <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning empty cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning empty cohort as `cohortId` is not valid.")
     cdm <- omopgenerics::emptyCohortTable(cdm = cdm, name = name)
     return(cdm[[name]])
   }

--- a/R/padCohortDate.R
+++ b/R/padCohortDate.R
@@ -176,7 +176,7 @@ padCohortStart <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cohort <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                        logPrefix = "CohortConstructor_.padCohortDate_empty_")

--- a/R/requireCohortIntersect.R
+++ b/R/requireCohortIntersect.R
@@ -64,7 +64,7 @@ requireCohortIntersect <- function(cohort,
   omopgenerics::assertLogical(atFirst, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireCohortIntersect_entry_1_")

--- a/R/requireConceptIntersect.R
+++ b/R/requireConceptIntersect.R
@@ -61,7 +61,7 @@ requireConceptIntersect <- function(cohort,
   omopgenerics::assertLogical(atFirst, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireConceptIntersect_entry_1_")

--- a/R/requireDateRange.R
+++ b/R/requireDateRange.R
@@ -52,7 +52,7 @@ requireInDateRange <- function(cohort,
   omopgenerics::assertLogical(atFirst, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireInDateRange_entry_")
@@ -223,7 +223,7 @@ trimToDateRange <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |>
       dplyr::compute(

--- a/R/requireDateRange.R
+++ b/R/requireDateRange.R
@@ -150,7 +150,8 @@ requireInDateRange <- function(cohort,
     dplyr::compute(name = name, temporary = FALSE,
                    logPrefix = "CohortConstructor_requireDateRange_name_") |>
     omopgenerics::newCohortTable(
-      .softValidation = TRUE, cohortAttritionRef = attrition(newCohort)
+      .softValidation = TRUE,
+      cohortAttritionRef = attr(newCohort, "cohort_attrition")
     )
 
   useIndexes <- getOption("CohortConstructor.use_indexes")

--- a/R/requireDemographics.R
+++ b/R/requireDemographics.R
@@ -262,7 +262,7 @@ demographicsFilter <- function(cohort,
   omopgenerics::assertLogical(atFirst, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |>
       dplyr::compute(

--- a/R/requireIsEntry.R
+++ b/R/requireIsEntry.R
@@ -30,7 +30,7 @@ requireIsEntry <- function(cohort,
   cohortId <- omopgenerics::validateCohortIdArgument({{cohortId}}, cohort, validation = "warning")
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |>
       dplyr::compute(
@@ -150,7 +150,7 @@ requireIsFirstEntry <- function(cohort,
   cohortId <- omopgenerics::validateCohortIdArgument({{cohortId}}, cohort, validation = "warning")
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireIsFirstEntry_entry_")
@@ -223,7 +223,7 @@ requireIsLastEntry <- function(cohort,
   cohortId <- omopgenerics::validateCohortIdArgument({{cohortId}}, cohort, validation = "warning")
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireIsLastEntry_entry_")

--- a/R/requireMinCohortCount.R
+++ b/R/requireMinCohortCount.R
@@ -40,7 +40,7 @@ requireMinCohortCount <- function(cohort,
   minCohortCount <- validateN(minCohortCount)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireMinCohortCount_entry_")

--- a/R/requireTableIntersect.R
+++ b/R/requireTableIntersect.R
@@ -50,7 +50,7 @@ requireTableIntersect <- function(cohort,
   omopgenerics::assertLogical(atFirst, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_requireTableIntersect_entry_")

--- a/R/sampleCohorts.R
+++ b/R/sampleCohorts.R
@@ -37,7 +37,7 @@ sampleCohorts <- function(cohort,
   omopgenerics::assertLogical(independent, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning entry cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning entry cohort as `cohortId` is not valid.")
     # return entry cohort as cohortId is used to modify not subset
     cdm[[name]] <- cohort |> dplyr::compute(name = name, temporary = FALSE,
                                             logPrefix = "CohortConstructor_sampleCohorts_entry_")

--- a/R/stratifyCohorts.R
+++ b/R/stratifyCohorts.R
@@ -50,7 +50,7 @@ stratifyCohorts <- function(cohort,
   omopgenerics::assertLogical(removeStrata, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning empty cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning empty cohort as `cohortId` is not valid.")
     cdm <- omopgenerics::emptyCohortTable(cdm = cdm, name = name)
     return(cdm[[name]])
   }

--- a/R/subsetCohorts.R
+++ b/R/subsetCohorts.R
@@ -34,7 +34,7 @@ subsetCohorts <- function(cohort,
   omopgenerics::assertLogical(negate, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning empty cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning empty cohort as `cohortId` is not valid.")
     cdm <- omopgenerics::emptyCohortTable(cdm = cdm, name = name)
     return(cdm[[name]])
   }

--- a/R/subsetCohorts.R
+++ b/R/subsetCohorts.R
@@ -46,9 +46,9 @@ subsetCohorts <- function(cohort,
                    logPrefix = "CohortConstructor_subsetCohorts_filter_")
   cdm[[name]] <- cdm[[name]] |>
     omopgenerics::newCohortTable(
-      cohortSetRef = settings(cohort) |>
+      cohortSetRef = attr(cohort, "cohort_set") |>
         dplyr::filter(.data$cohort_definition_id %in% .env$cohortId),
-      cohortAttritionRef = attrition(cohort) |>
+      cohortAttritionRef = attr(cohort, "cohort_attrition") |>
         dplyr::filter(.data$cohort_definition_id %in% .env$cohortId),
       cohortCodelistRef = attr(cohort, "cohort_codelist") |>
         dplyr::filter(.data$cohort_definition_id %in% .env$cohortId),
@@ -61,9 +61,9 @@ subsetCohorts <- function(cohort,
                      logPrefix = "CohortConstructor_subsetCohorts_filter_")
     cdm[[name]] <- cdm[[name]] |>
       omopgenerics::newCohortTable(
-        cohortSetRef = settings(cohort) |>
+        cohortSetRef = attr(cohort, "cohort_set") |>
           dplyr::filter(!.data$cohort_definition_id %in% .env$cohortId),
-        cohortAttritionRef = attrition(cohort) |>
+        cohortAttritionRef = attr(cohort, "cohort_attrition") |>
           dplyr::filter(!.data$cohort_definition_id %in% .env$cohortId),
         cohortCodelistRef = attr(cohort, "cohort_codelist") |>
           dplyr::filter(!.data$cohort_definition_id %in% .env$cohortId),

--- a/R/timeWindowCohorts.R
+++ b/R/timeWindowCohorts.R
@@ -47,7 +47,7 @@ timeWindowCohorts <- function (cohort,
   omopgenerics::assertLogical(keepOriginalCohorts, length = 1)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning empty cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning empty cohort as `cohortId` is not valid.")
     cdm <- omopgenerics::emptyCohortTable(cdm = cdm, name = name)
     return(cdm[[name]])
   }

--- a/R/trimDemographics.R
+++ b/R/trimDemographics.R
@@ -42,7 +42,7 @@ trimDemographics <- function(cohort,
   )
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning empty cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning empty cohort as `cohortId` is not valid.")
     cdm <- omopgenerics::emptyCohortTable(cdm = cdm, name = name)
     return(cdm[[name]])
   }

--- a/R/yearCohorts.R
+++ b/R/yearCohorts.R
@@ -37,7 +37,7 @@ yearCohorts <- function(cohort,
   omopgenerics::assertLogical(.softValidation)
 
   if (length(cohortId) == 0) {
-    cli::cli_inform("Returning empty cohort as `cohortId` is not valid.")
+    cli::cli_warn("Returning empty cohort as `cohortId` is not valid.")
     cdm <- omopgenerics::emptyCohortTable(cdm = cdm, name = name)
     return(cdm[[name]])
   }


### PR DESCRIPTION
hey @edward-burn @nmercadeb omopgenerics 1.4.0 broke tests for CohortConstructor but we did not realise because they are all skipped in cran. The problem is that invalid cohortId throws one warning less... and then all the tests that expect 2/3 warning they got one less. Added the warning back so tests work fine. Please tell me what you think. It would be nice to fix this asap, otherwise all the contributing PR fail due to this